### PR TITLE
修复 isHevc 函数

### DIFF
--- a/packages/yyeva/src/helper/polyfill.ts
+++ b/packages/yyeva/src/helper/polyfill.ts
@@ -64,6 +64,7 @@ export const isHevc = (video: HTMLVideoElement) => {
   // console.log('video/mp4; codecs="hev1.2.4.L120.B0"', video.canPlayType('video/mp4; codecs="hev1.2.4.L120.B0"'))
   return !!(
     video.canPlayType('video/mp4; codecs="hev1.1.6.L93.B0"') ||
+    video.canPlayType('video/mp4; codecs="hvc1.1.6.L93.B0"') ||
     video.canPlayType('video/mp4; codecs="hev1.2.4.L120.B0"')
   )
 }


### PR DESCRIPTION
### 当前问题

- 当前绝大多数移动设备都可以通过video标签直接播放 h.265 视频，比如我的 iphone 13 pro。但是源码中 isHevc 函数始终返回 false，导致请求了更大的 h.264 视频资源。
- 检测通过 AE 插件 YY-MP4 转换导出的 mp4 文件，发现它是的 codecs 是 hvc1.1.6.L123.90，而 isHevc 函数检测了更为专业hev1.1.6.L123.90， 却并未包含更简单且兼容性更好的 hvc1.1.6.L123.90 的检测，导致绝大部分移动设备 isHevc 函数都返回 false，最终导致绝大部分移动设备都只能播放资源更大 h.264 视频，对于带宽更窄的移动端来说，这是致命的。关键，**YY-MP4 转换导出的 mp4 是  hvc1.1.6.L123.90**。
![image](https://github.com/yylive/YYEVA-Web/assets/73691835/dc48532e-f066-43b6-9f85-e7f383209720)
### 解决方案
添加 hvc1.1.6.L123.90 检测
```
export const isHevc = (video: HTMLVideoElement) => {
  // https://cconcolato.github.io/media-mime-support/
  // console.log('video/mp4; codecs="hev1.1.6.L93.B0"', video.canPlayType('video/mp4; codecs="hev1.1.6.L93.B0"'))
  // console.log('video/mp4; codecs="hev1.2.4.L120.B0"', video.canPlayType('video/mp4; codecs="hev1.2.4.L120.B0"'))
  return !!(
    video.canPlayType('video/mp4; codecs="hev1.1.6.L93.B0"') ||
    // 这是新增的检测，大部分移动设备的值是 properly，可播放
    video.canPlayType('video/mp4; codecs="hvc1.1.6.L93.B0"') ||
    video.canPlayType('video/mp4; codecs="hev1.2.4.L120.B0"')
  )
}
```
