### PR TITLE
修复 WechatPolyfill.initVideoIDPosition 在 WeixinJSBridgeReady 触发后调用用无效

### DIFF
--- a/packages/yyeva/src/helper/polyfill.ts
+++ b/packages/yyeva/src/helper/polyfill.ts
@@ -84,16 +84,25 @@ class WechatPolyfill {
     if (!polyfill.weixin || !polyfill.ios) {
       return
     }
-    //
-    document.addEventListener('WeixinJSBridgeReady', () => {
-      this.ready = true
+    const mountVideoDoms = () => {
       list.map(v => {
         const video = document.createElement('video')
         video.setAttribute('id', v)
         document.body.appendChild(video)
         video.style.visibility = 'hidden'
       })
-    })
+    }
+    if ((window as any).WeixinJSBridge) {
+      (window as any).WeixinJSBridge.invoke('getNetworkType', {}, () => {
+        this.ready = true
+        mountVideoDoms()
+      })
+    } else {
+      document.addEventListener('WeixinJSBridgeReady', () => {
+        this.ready = true
+        mountVideoDoms()
+      })
+    }
   }
   wxReady() {
     logger.debug('[wxReady] resolve', this.ready)


### PR DESCRIPTION
在某些场景下，yyeva 需要在页面加载完成后再实例化，此时微信内浏览器的 `WeixinJSBridgeReady` 已经触发，`initVideoIDPosition` 函数的调用是无效的，yyeva 内部会一直等待微信状态 ready。

该 Commit 通过判断是否已经存在 `WeixinJSBridge`，如果存在，通过在 `invoke` 方法的回调中创建 video DOM，经测试可以避免这一问题。